### PR TITLE
Update 6. DL 2. Convolutional networks.ipynb

### DIFF
--- a/6. Deep Learning/6. DL 2. Convolutional networks.ipynb
+++ b/6. Deep Learning/6. DL 2. Convolutional networks.ipynb
@@ -445,8 +445,8 @@
     }
    ],
    "source": [
-    "w=model_2.get_layer(\"conv\").weights[0].get_value()\n",
-    "w=w.reshape(3,3)\n",
+    "w=model_2.get_layer(\"conv\").get_weights()\n",
+    "w=w[0].reshape(3,3)\n",
     "w"
    ]
   },


### PR DESCRIPTION
Changed:
w=model_2.get_layer("conv").weights[0].get_value()
w=w.reshape(3,3)
w

to:
w=model_2.get_layer("conv").get_weights()
w=w[0].reshape(3,3)
w

as the former gave an error.